### PR TITLE
Valid aws url

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -24,3 +24,4 @@ Moo               	 = 0
 Ouch              	 = 0
 Crypt::OpenSSL::RSA  = 0
 Crypt::OpenSSL::X509 = 0
+URI::URL             = 0

--- a/dist.ini
+++ b/dist.ini
@@ -15,11 +15,12 @@ repository.web    = http://github.com/rizen/AWS-SNS-Verify
 repository.type   = git
 
 [Prereqs]
-Test::More        	= 0
-JSON		  	= 0
-HTTP::Tiny        	= 0
-MIME::Base64      	= 0
-Moo               	= 0
-Ouch              	= 0
-Crypt::OpenSSL::RSA 	= 0
-Crypt::OpenSSL::X509 	= 0
+Test::More        	 = 0
+Test::Exception      = 0
+JSON		  	     = 0
+HTTP::Tiny        	 = 0
+MIME::Base64      	 = 0
+Moo               	 = 0
+Ouch              	 = 0
+Crypt::OpenSSL::RSA  = 0
+Crypt::OpenSSL::X509 = 0

--- a/dist.ini
+++ b/dist.ini
@@ -15,13 +15,13 @@ repository.web    = http://github.com/rizen/AWS-SNS-Verify
 repository.type   = git
 
 [Prereqs]
-Test::More        	 = 0
+Test::More           = 0
 Test::Exception      = 0
-JSON		  	     = 0
-HTTP::Tiny        	 = 0
-MIME::Base64      	 = 0
-Moo               	 = 0
-Ouch              	 = 0
+JSON                 = 0
+HTTP::Tiny           = 0
+MIME::Base64         = 0
+Moo                  = 0
+Ouch                 = 0
 Crypt::OpenSSL::RSA  = 0
 Crypt::OpenSSL::X509 = 0
 URI::URL             = 0

--- a/lib/AWS/SNS/Verify.pm
+++ b/lib/AWS/SNS/Verify.pm
@@ -164,7 +164,9 @@ Required. JSON string posted by AWS SNS. Looks like:
 
 =item certificate_string
 
-By default AWS::SNS::Verify will fetch the certificate string by issuing an HTTP GET request to C<SigningCertURL>. If you wish to use a cached version, then pass it in.
+By default AWS::SNS::Verify will fetch the certificate string by issuing an HTTP GET request to C<SigningCertURL>. The SigningCertURL in the message must be a AWS SNS endpoint.
+
+If you wish to use a cached version, then pass it in.
 
 =back
 

--- a/lib/AWS/SNS/Verify.pm
+++ b/lib/AWS/SNS/Verify.pm
@@ -43,6 +43,12 @@ has certificate => (
     }
 );
 
+has validate_signing_cert_url => (
+    is      => 'ro',
+    lazy    => 1,
+    default => 1,
+);
+
 sub fetch_certificate {
     my $self = shift;
     my $url = $self->valid_cert_url($self->message->{SigningCertURL});
@@ -95,6 +101,8 @@ sub valid_cert_url {
     my $self = shift;
     my ($url_string) = @_;
     $url_string ||= '';
+
+    return $url_string unless $self->validate_signing_cert_url;
 
     my $url = URI::URL->new($url_string);
     unless ( $url->can('host') ) {
@@ -167,6 +175,12 @@ Required. JSON string posted by AWS SNS. Looks like:
 By default AWS::SNS::Verify will fetch the certificate string by issuing an HTTP GET request to C<SigningCertURL>. The SigningCertURL in the message must be a AWS SNS endpoint.
 
 If you wish to use a cached version, then pass it in.
+
+=item validate_signing_cert_url (default: true)
+
+If you're using a fake SNS server in your local test environment, the SigningCertURL won't be an AWS endpoint. If so, set validate_signing_cert_url to 0.
+
+Don't ever do this in any kind of Production environment.
 
 =back
 

--- a/lib/AWS/SNS/Verify.pm
+++ b/lib/AWS/SNS/Verify.pm
@@ -172,7 +172,7 @@ If you wish to use a cached version, then pass it in.
 
 =head2 verify
 
-Returns a 1 on success, or an L<Ouch> on a failure.
+Returns a 1 on success, or die with an L<Ouch> on a failure.
 
 =head2 message
 

--- a/t/02_valid_cert_url.t
+++ b/t/02_valid_cert_url.t
@@ -44,4 +44,15 @@ is(
 
 
 
+my $no_validate_sns = AWS::SNS::Verify->new(body => '', validate_signing_cert_url => 0);
+my $test_server_url = "http://my.local.test.server/cert.pem";
+is(
+    $no_validate_sns->valid_cert_url($test_server_url),
+    $test_server_url,
+    "Accept any URL if no validation",
+);
+
+
+
+
 done_testing();

--- a/t/02_valid_cert_url.t
+++ b/t/02_valid_cert_url.t
@@ -1,0 +1,47 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+
+use lib '../lib';
+
+use AWS::SNS::Verify;
+
+
+my $sns = AWS::SNS::Verify->new(body => '');
+
+throws_ok(
+    sub { $sns->valid_cert_url(undef) },
+    qr/\QThe SigningCertURL () isn't a valid URL/,
+);
+
+throws_ok(
+    sub { $sns->valid_cert_url("abc") },
+    qr/\QThe SigningCertURL (abc) isn't a valid URL/,
+);
+
+
+throws_ok(
+    sub { $sns->valid_cert_url("http://my.bad.com/cert.pem") },
+    qr|\QThe SigningCertURL (http://my.bad.com/cert.pem) isn't an Amazon endpoint|,
+);
+
+
+
+my $valid_euwest_url = "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-b95095beb82e8f6a046b3aafc7f4149a.pem";
+is(
+    $sns->valid_cert_url($valid_euwest_url),
+    $valid_euwest_url,
+    "Valid url returns url",
+);
+
+my $valid_china_url = "https://sns.cn-north-1.amazonaws.com.cn/SimpleNotificationService-3242342098.pem";
+is(
+    $sns->valid_cert_url($valid_china_url),
+    $valid_china_url,
+    "Valid China url returns valid url",
+);
+
+
+
+done_testing();


### PR DESCRIPTION
This adds an attribute validate_signing_cert_url (default: true) and validates that the SigningCertURL in the message is a legit AWS endpoint before using it.

I started by adding some more normal use test coverage, if you want that in a different PR there's a branch for that.