### PR TITLE
Remove deps to Crypt::OpenSSL::RSA and Crypt::OpenSSL::X509

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -15,13 +15,12 @@ repository.web    = http://github.com/rizen/AWS-SNS-Verify
 repository.type   = git
 
 [Prereqs]
-Test::More           = 0
-Test::Exception      = 0
-JSON                 = 0
-HTTP::Tiny           = 0
-MIME::Base64         = 0
-Moo                  = 0
-Ouch                 = 0
-Crypt::OpenSSL::RSA  = 0
-Crypt::OpenSSL::X509 = 0
-URI::URL             = 0
+Test::More      = 0
+Test::Exception = 0
+JSON            = 0
+HTTP::Tiny      = 0
+MIME::Base64    = 0
+Moo             = 0
+Ouch            = 0
+CryptX          = 0
+URI::URL        = 0

--- a/lib/AWS/SNS/Verify.pm
+++ b/lib/AWS/SNS/Verify.pm
@@ -7,8 +7,7 @@ use HTTP::Tiny;
 use MIME::Base64;
 use Moo;
 use Ouch;
-use Crypt::OpenSSL::RSA;
-use Crypt::OpenSSL::X509;
+use Crypt::PK::RSA;
 use URI::URL;
 
 has body => (
@@ -39,7 +38,7 @@ has certificate => (
     lazy        => 1,
     default     => sub {
         my $self = shift;
-        return Crypt::OpenSSL::X509->new_from_string($self->certificate_string);
+        return Crypt::PK::RSA->new(\$self->certificate_string);
     }
 );
 
@@ -88,8 +87,8 @@ sub decode_signature {
 
 sub verify {
     my $self = shift;
-    my $rsa = Crypt::OpenSSL::RSA->new_public_key($self->certificate->pubkey);
-    unless ($rsa->verify($self->generate_signature_string, $self->decode_signature)) {
+    my $pk = $self->certificate;
+    unless ($pk->verify_message($self->decode_signature, $self->generate_signature_string, 'SHA1', 'v1.5')) {
         ouch 'Bad SNS Signature', 'Could not verify the SES message from its signature.', $self;
     }
     return 1;

--- a/t/01_verify.t
+++ b/t/01_verify.t
@@ -109,7 +109,7 @@ note "Invalid cert doesn't validate";
 my $invalid_cert_sns = AWS::SNS::Verify->new(body => $body, certificate_string => "Nopes");
 throws_ok(
     sub { $invalid_cert_sns->verify },
-    qr/X509/,
+    qr/FATAL: invalid or unsupported RSA key format/,
     "Invalid cert doesn't valiate",
 );
 


### PR DESCRIPTION
This PR removes `Crypt::OpenSSL::RSA` and `Crypt::OpenSSL::X509` due to a installation problem on macOS >= 10.11.
I used `CryptX` instead of modules related to OpenSSL. This module doesn't require OpenSSL library and so easy to install.